### PR TITLE
将参数分割改为通过第一个=分割，满足动态条件的需求

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -138,14 +138,14 @@ onMounted(() => {
     </a-row>
     <div style="margin-top: 16px" />
     <a-row :gutter="[16, 16]">
-      <a-col :sm="24" :md="12">
+      <a-col :sm="24" :md="14">
         <div
           id="inputContainer"
           ref="inputContainer"
           style="height: 80vh; max-width: 100%"
         />
       </a-col>
-      <a-col :sm="24" :md="12">
+      <a-col :sm="24" :md="10">
         <div
           id="outputContainer"
           ref="outputContainer"

--- a/src/App.vue
+++ b/src/App.vue
@@ -138,14 +138,14 @@ onMounted(() => {
     </a-row>
     <div style="margin-top: 16px" />
     <a-row :gutter="[16, 16]">
-      <a-col :sm="24" :md="14">
+      <a-col :sm="24" :md="12">
         <div
           id="inputContainer"
           ref="inputContainer"
           style="height: 80vh; max-width: 100%"
         />
       </a-col>
-      <a-col :sm="24" :md="10">
+      <a-col :sm="24" :md="12">
         <div
           id="outputContainer"
           ref="outputContainer"

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -155,13 +155,10 @@ function replaceSubSql(
     // string => object
     const params: Record<string, string> = {};
     for (const singleParamsStr of singleParamsStrArray) {
-      // 必须分成 2 段
-      const keyValueArray = singleParamsStr.split("=", 2);
-      if (keyValueArray.length < 2) {
-        continue;
-      }
-      const key = keyValueArray[0].trim();
-      params[key] = keyValueArray[1].trim();
+      // 以第一个=分割字符串
+      const splitIndex = singleParamsStr.indexOf("=");
+      const key = singleParamsStr.slice(0, splitIndex).trim();
+      params[key] = singleParamsStr.slice(splitIndex + 1).trim();
     }
     // 递归解析被替换节点
     const replacement = generateSQL(subKey, context, params, invokeTreeNode);


### PR DESCRIPTION
鱼皮哥您好，我在使用程序的时候，遇到一个情况，如下
1. 需要查询1年级学生数量
2. 需要查询2年级2班学生数量
主要问题就出在这个2班这里，这个参数不能写死（class = #{class}），因为第一个查询他不需要所以我是这样写的。
![image](https://user-images.githubusercontent.com/70745111/177077292-a770f16e-a180-4bf3-8ffc-856d471b92f7.png)
但是呢=被切割了，所以有错误，所以我改成了通过第一个=分割，我觉得这比较合理，可以满足动态条件的需要，实际效果如下。
![image](https://user-images.githubusercontent.com/70745111/177078054-5f679cb1-e688-49ce-9642-b8a31c100df0.png)
![image](https://user-images.githubusercontent.com/70745111/177078084-e4e976ab-1c01-4e78-9ed9-9d9f95feeb94.png)
